### PR TITLE
add buy input error handler

### DIFF
--- a/GiftcardRecord/GiftcardRecord/main.cpp
+++ b/GiftcardRecord/GiftcardRecord/main.cpp
@@ -73,6 +73,11 @@ BUY:
 		if (select == 0) {
 			goto HOME;
 		}
+		
+		if (select > 4) {
+			cout << "invalid number...\n";
+			goto BUY;
+		}
 
 		Transaction * tx = w1_.createTransaction(w2_.getPublicKey(), giftcardList[select]->getName(), giftcardList[select]->getFaceValue(), 0, "Buy");
 		Transaction * tx2 = w2_.createTransaction(w1_.getPublicKey(), "coin", giftcardList[select]->getMarketValue(), 0, "Buy");


### PR DESCRIPTION
#5 [input 관련 issue]에서 말했던 것처럼 input이 5이상의 숫자면 추후 프로그램이 터지는 현상을 select에 대한 예외 처리를 통해 해결하였습니다.